### PR TITLE
fix(api): Update Jore GraphQL API URL to new prod

### DIFF
--- a/publisher-scripts/generateStopsPdf.js
+++ b/publisher-scripts/generateStopsPdf.js
@@ -7,7 +7,7 @@ const timetableCount = parseInt(process.env.STOP_TIMETABLE_LIMIT) || 0;
 
 
 
-const API_URL = "https://kartat.hsldev.com/jore/graphql";
+const API_URL = "https://prod.kartat.hsl.fi/jore/graphql";
 
 async function fetchStopIds() {
     const options = {


### PR DESCRIPTION
The kartat.hsldev.com is ceasing to exist. Update the Jore GraphQL API URL for querying stopId:s to the new karttatuotanto production environment.